### PR TITLE
Fix potential divide by zero error for the DateTime tick provider

### DIFF
--- a/community_charts_common/lib/src/chart/cartesian/axis/time/auto_adjusting_date_time_tick_provider.dart
+++ b/community_charts_common/lib/src/chart/cartesian/axis/time/auto_adjusting_date_time_tick_provider.dart
@@ -134,6 +134,9 @@ class AutoAdjustingDateTimeTickProvider implements TickProvider<DateTime> {
 
   /// Find the closest tick provider based on the tick hint.
   TimeRangeTickProvider _getClosestTickProvider(TickHint<DateTime> tickHint) {
+    if (tickHint.tickCount < 2) {
+      return _potentialTickProviders.last;
+    }
     final stepSize = ((tickHint.end.difference(tickHint.start).inMilliseconds) /
             (tickHint.tickCount - 1))
         .round();


### PR DESCRIPTION
When a chart with an AutoAdjustingDateTimeTickProvider on one axis is zoomed in to the point where only one tick is visible, the console gets flooded with divide by zero warnings.

I'm not sure if this will be encountered under usual circumstances; my chart configuration had specific positions for the ticks. Still, it's seems like a good safety measure.