### PR TITLE
Added UserManagedState to Combo charts

### DIFF
--- a/community_charts_flutter/lib/src/combo_chart/combo_chart.dart
+++ b/community_charts_flutter/lib/src/combo_chart/combo_chart.dart
@@ -27,6 +27,7 @@ import '../base_chart.dart' show LayoutConfig;
 import '../base_chart_state.dart' show BaseChartState;
 import '../cartesian_chart.dart' show CartesianChart;
 import '../selection_model_config.dart' show SelectionModelConfig;
+import '../user_managed_state.dart';
 
 /// A numeric combo chart supports rendering each series of data with different
 /// series renderers.
@@ -48,6 +49,7 @@ class NumericComboChart extends CartesianChart<num> {
     List<SelectionModelConfig<num>>? selectionModels,
     common.RTLSpec? rtlSpec,
     LayoutConfig? layoutConfig,
+    UserManagedState<num>? userManagedState,
     bool defaultInteractions = true,
   }) : super(
           seriesList,
@@ -62,6 +64,7 @@ class NumericComboChart extends CartesianChart<num> {
           selectionModels: selectionModels,
           rtlSpec: rtlSpec,
           layoutConfig: layoutConfig,
+          userManagedState: userManagedState,
           defaultInteractions: defaultInteractions,
         );
 
@@ -93,6 +96,7 @@ class OrdinalComboChart extends CartesianChart<String> {
     List<SelectionModelConfig<String>>? selectionModels,
     common.RTLSpec? rtlSpec,
     LayoutConfig? layoutConfig,
+    UserManagedState<String>? userManagedState,
     bool defaultInteractions = true,
   }) : super(
           seriesList,
@@ -107,6 +111,7 @@ class OrdinalComboChart extends CartesianChart<String> {
           selectionModels: selectionModels,
           rtlSpec: rtlSpec,
           layoutConfig: layoutConfig,
+          userManagedState: userManagedState,
           defaultInteractions: defaultInteractions,
         );
 


### PR DESCRIPTION
Combo charts did not include UserManagedState in constructor, which made it impossible to create e.g. a popup on the selected line datum.

•Added UserManagedState variable to be passed down into the super constructor on NumericComboChart and OrdinalComboChart

•Tested manually by using the combo chart example and changing it into a stateful widget. Then created userManagedState and saw worked as intended.