### PR TITLE
Fix multiple null exceptions when tapping on bar graph rapidly

### DIFF
--- a/community_charts_common/lib/src/chart/bar/bar_renderer.dart
+++ b/community_charts_common/lib/src/chart/bar/bar_renderer.dart
@@ -86,11 +86,11 @@ class BarRenderer<D>
     final domainAxis = series.getAttr(domainAxisKey) as ImmutableAxis<D>;
     final measureAxis = series.getAttr(measureAxisKey) as ImmutableAxis<num>;
 
-    final barGroupIndex = series.getAttr(barGroupIndexKey)!;
+    final barGroupIndex = series.getAttr(barGroupIndexKey) ?? 0;
     final previousBarGroupWeight = series.getAttr(previousBarGroupWeightKey);
     final barGroupWeight = series.getAttr(barGroupWeightKey);
     final allBarGroupWeights = series.getAttr(allBarGroupWeightsKey);
-    final numBarGroups = series.getAttr(barGroupCountKey)!;
+    final numBarGroups = series.getAttr(barGroupCountKey) ?? 0;
 
     final bounds = _getBarBounds(
         details.domain,
@@ -409,6 +409,7 @@ class BarRenderer<D>
     // TODO: Investigate why this is negative for a DateTime domain
     // in RTL mode.
     domainWidth = domainWidth.abs();
+    if (numBarGroups == 0) numBarGroups = 1;
 
     // If no weights were passed in, default to equal weight per bar.
     if (barGroupWeight == null) {

--- a/community_charts_common/lib/src/chart/layout/layout_manager_impl.dart
+++ b/community_charts_common/lib/src/chart/layout/layout_manager_impl.dart
@@ -117,7 +117,7 @@ class LayoutManagerImpl implements LayoutManager {
 
   @override
   Rectangle<int> get drawableLayoutAreaBounds {
-    assert(_drawAreaBoundsOutdated == false);
+    if (_drawAreaBoundsOutdated != false) return Rectangle(0, 0, 0, 0);
 
     final drawableViews =
         _views.where((LayoutView view) => view.isSeriesRenderer);

--- a/community_charts_flutter/lib/src/widget_layout_delegate.dart
+++ b/community_charts_flutter/lib/src/widget_layout_delegate.dart
@@ -122,14 +122,14 @@ class WidgetLayoutDelegate extends MultiChildLayoutDelegate {
       switch (horizontalJustification) {
         case _HorizontalJustification.leftDrawArea:
           behaviorOffset = new Offset(
-              behavior.drawAreaBounds!.left.toDouble(), heightOffset);
+              behavior.drawAreaBounds?.left.toDouble() ?? 0.0, heightOffset);
           break;
         case _HorizontalJustification.left:
           behaviorOffset = new Offset(0.0, heightOffset);
           break;
         case _HorizontalJustification.rightDrawArea:
           behaviorOffset = new Offset(
-              behavior.drawAreaBounds!.right - behaviorSize.width,
+              (behavior.drawAreaBounds?.right ?? behaviorSize.width) - behaviorSize.width,
               heightOffset);
           break;
         case _HorizontalJustification.right:
@@ -149,7 +149,7 @@ class WidgetLayoutDelegate extends MultiChildLayoutDelegate {
         case common.OutsideJustification.startDrawArea:
         case common.OutsideJustification.middleDrawArea:
           behaviorOffset =
-              new Offset(widthOffset, behavior.drawAreaBounds!.top.toDouble());
+              new Offset(widthOffset, behavior.drawAreaBounds?.top.toDouble() ?? 0.0);
           break;
         case common.OutsideJustification.start:
         case common.OutsideJustification.middle:
@@ -157,7 +157,7 @@ class WidgetLayoutDelegate extends MultiChildLayoutDelegate {
           break;
         case common.OutsideJustification.endDrawArea:
           behaviorOffset = new Offset(widthOffset,
-              behavior.drawAreaBounds!.bottom - behaviorSize.height);
+              (behavior.drawAreaBounds?.bottom ?? behaviorSize.height) - behaviorSize.height);
           break;
         case common.OutsideJustification.end:
           behaviorOffset =


### PR DESCRIPTION
When tapping on bar graph rapidly, there is a race condition between bar selection and graph rendering, causing null exceptions at various places.

This is one of the exceptions:

```

-------- Exception caught by rendering library ---------------------------------
The following _TypeError was thrown during performLayout():
Null check operator used on a null value

The relevant error-causing widget was:
    OrdinalComboChart OrdinalComboChart:file:///E:/work/app/lib/screens/stat_chart.dart:485:18

When the exception was thrown, this was the stack:
#0      BarRenderer.addPositionToDetailsForSeriesDatum (package:community_charts_common/src/chart/bar/bar_renderer.dart:89:59)
bar_renderer.dart:89
#1      BaseSeriesRenderer.getDetailsForSeriesDatum (package:community_charts_common/src/chart/common/series_renderer.dart:402:12)
series_renderer.dart:402
#2      BaseChart.getSelectedDatumDetails (package:community_charts_common/src/chart/common/base_chart.dart:318:41)
base_chart.dart:318
#3      LinePointHighlighter._updateViewData (package:community_charts_common/src/chart/common/behavior/line_point_highlighter.dart:198:16)
line_point_highlighter.dart:198
#4      BaseChart.fireOnAxisConfigured.<anonymous closure> (package:community_charts_common/src/chart/common/base_chart.dart:686:34)
base_chart.dart:686
#5      List.forEach (dart:core-patch/growable_array.dart:416:8)
growable_array.dart:416
#6      BaseChart.fireOnAxisConfigured (package:community_charts_common/src/chart/common/base_chart.dart:685:25)
base_chart.dart:685
#7      CartesianChart.onPostLayout (package:community_charts_common/src/chart/cartesian/cartesian_chart.dart:491:5)
cartesian_chart.dart:491
#8      BaseChart.layout (package:community_charts_common/src/chart/common/base_chart.dart:441:7)
base_chart.dart:441
#9      ChartContainerRenderObject.performLayout (package:community_charts_flutter/src/chart_container.dart:171:13)
chart_container.dart:171
#10     RenderObject.layout (package:flutter/src/rendering/object.dart:2577:7)
object.dart:2577
#11     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:105:21)
proxy_box.dart:105
#12     RenderObject._layoutWithoutResize (package:flutter/src/rendering/object.dart:2416:7)
object.dart:2416
#13     PipelineOwner.flushLayout (package:flutter/src/rendering/object.dart:1051:18)
object.dart:1051
#14     PipelineOwner.flushLayout (package:flutter/src/rendering/object.dart:1064:15)
object.dart:1064
#15     RendererBinding.drawFrame (package:flutter/src/rendering/binding.dart:577:23)
binding.dart:577
#16     WidgetsBinding.drawFrame (package:flutter/src/widgets/binding.dart:1138:13)
binding.dart:1138
#17     RendererBinding._handlePersistentFrameCallback (package:flutter/src/rendering/binding.dart:443:5)
binding.dart:443
#18     SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1392:15)
binding.dart:1392
#19     SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1313:9)
binding.dart:1313
#20     SchedulerBinding._handleDrawFrame (package:flutter/src/scheduler/binding.dart:1171:5)
binding.dart:1171
#21     _invoke (dart:ui/hooks.dart:312:13)
hooks.dart:312
#22     PlatformDispatcher._drawFrame (dart:ui/platform_dispatcher.dart:419:5)
platform_dispatcher.dart:419
#23     _drawFrame (dart:ui/hooks.dart:283:31)
hooks.dart:283

The following RenderObject was being processed when the exception was fired: ChartContainerRenderObject<String>#db013 NEEDS-LAYOUT NEEDS-PAINT
    parentData: <none> (can use size)
    constraints: BoxConstraints(w=324.0, h=201.1)
    semantic boundary
    size: Size(324.0, 201.1)
    painter: ChartContainerCustomPaint#33163()
RenderObject: ChartContainerRenderObject<String>#db013 NEEDS-LAYOUT NEEDS-PAINT
    parentData: <none> (can use size)
    constraints: BoxConstraints(w=324.0, h=201.1)
    semantic boundary
    size: Size(324.0, 201.1)
    painter: ChartContainerCustomPaint#33163()
--------------------------------------------------------------------------------
```

