### PR TITLE
Feature: Chart behaviour: When tapping on a graph, use maximumDomainDistancePx relative to tap position to select or deselect data point on the graph

### DIFF
--- a/community_charts_common/lib/src/chart/common/base_chart.dart
+++ b/community_charts_common/lib/src/chart/common/base_chart.dart
@@ -256,19 +256,21 @@ abstract class BaseChart<D> {
   /// selection should be done across the combined draw area of all components
   /// with series draw areas, or just the chart's primary draw area bounds.
   List<DatumDetails<D>> getNearestDatumDetailPerSeries(
-      Point<double> drawAreaPoint, bool selectAcrossAllDrawAreaComponents) {
+      Point<double> drawAreaPoint, bool selectAcrossAllDrawAreaComponents, {bool? selectNearestByDomainOverride}) {
     // Optionally grab the combined draw area bounds of all components. If this
     // is disabled, then we expect each series renderer to filter out the event
     // if [chartPoint] is located outside of its own component bounds.
     final boundsOverride =
         selectAcrossAllDrawAreaComponents ? drawableLayoutAreaBounds : null;
 
+    bool _selectNearestByDomain = selectNearestByDomain;
+    if (selectNearestByDomainOverride != null) _selectNearestByDomain = selectNearestByDomainOverride;
     final details = <DatumDetails<D>>[];
     _usingRenderers.forEach((String rendererId) {
       details
           .addAll(getSeriesRenderer(rendererId).getNearestDatumDetailPerSeries(
         drawAreaPoint,
-        selectNearestByDomain,
+        _selectNearestByDomain,
         boundsOverride,
         selectOverlappingPoints: selectOverlappingPoints,
         selectExactEventLocation: selectExactEventLocation,

--- a/community_charts_flutter/lib/src/behaviors/select_nearest.dart
+++ b/community_charts_flutter/lib/src/behaviors/select_nearest.dart
@@ -58,6 +58,7 @@ class SelectNearest<D> extends ChartBehavior<D> {
   final bool selectAcrossAllDrawAreaComponents;
   final bool selectClosestSeries;
   final int? maximumDomainDistancePx;
+  final bool? useRelativeDistance;
 
   SelectNearest._internal(
       {required this.selectionModelType,
@@ -66,7 +67,8 @@ class SelectNearest<D> extends ChartBehavior<D> {
       this.selectClosestSeries = true,
       required this.eventTrigger,
       required this.desiredGestures,
-      this.maximumDomainDistancePx});
+      this.maximumDomainDistancePx,
+      this.useRelativeDistance});
 
   factory SelectNearest(
       {common.SelectionModelType selectionModelType =
@@ -75,7 +77,8 @@ class SelectNearest<D> extends ChartBehavior<D> {
       bool selectAcrossAllDrawAreaComponents = false,
       bool selectClosestSeries = true,
       common.SelectionTrigger eventTrigger = common.SelectionTrigger.tap,
-      int? maximumDomainDistancePx}) {
+      int? maximumDomainDistancePx,
+      bool? useRelativeDistance}) {
     return new SelectNearest._internal(
         selectionModelType: selectionModelType,
         selectionMode: selectionMode,
@@ -83,7 +86,8 @@ class SelectNearest<D> extends ChartBehavior<D> {
         selectClosestSeries: selectClosestSeries,
         eventTrigger: eventTrigger,
         desiredGestures: SelectNearest._getDesiredGestures(eventTrigger),
-        maximumDomainDistancePx: maximumDomainDistancePx);
+        maximumDomainDistancePx: maximumDomainDistancePx,
+        useRelativeDistance: useRelativeDistance);
   }
 
   static Set<GestureType> _getDesiredGestures(
@@ -120,7 +124,8 @@ class SelectNearest<D> extends ChartBehavior<D> {
         eventTrigger: eventTrigger,
         selectionMode: selectionMode,
         selectClosestSeries: selectClosestSeries,
-        maximumDomainDistancePx: maximumDomainDistancePx);
+        maximumDomainDistancePx: maximumDomainDistancePx,
+        useRelativeDistance: useRelativeDistance);
   }
 
   @override
@@ -137,7 +142,8 @@ class SelectNearest<D> extends ChartBehavior<D> {
           (eventTrigger == other.eventTrigger) &&
           (selectionMode == other.selectionMode) &&
           (selectClosestSeries == other.selectClosestSeries) &&
-          (maximumDomainDistancePx == other.maximumDomainDistancePx);
+          (maximumDomainDistancePx == other.maximumDomainDistancePx) &&
+          (useRelativeDistance == other.useRelativeDistance);
     } else {
       return false;
     }
@@ -149,6 +155,9 @@ class SelectNearest<D> extends ChartBehavior<D> {
     hashcode = hashcode * 37 + selectionMode.hashCode;
     hashcode = hashcode * 37 + selectClosestSeries.hashCode;
     hashcode = hashcode * 37 + maximumDomainDistancePx.hashCode;
+    if (useRelativeDistance != null) {
+      hashcode = hashcode * 37 + useRelativeDistance.hashCode;
+    }
     return hashcode;
   }
 }


### PR DESCRIPTION
When tapping on graph, data point nearest to tap position within the `maximumDomainDistancePx` radius is selected. If no data point within the `maximumDomainDistancePx` radius, then the currently selected data point is deselected.

Example usage:
```dart
      charts.SelectNearest<String>(
        eventTrigger: charts.SelectionTrigger.tap,
        maximumDomainDistancePx: 10,
        useRelativeDistance: true,
      );
```