### PR TITLE
Feature: arc renderer config: support configurable stroke color

### DIFF
--- a/community_charts_common/lib/src/chart/pie/arc_renderer_config.dart
+++ b/community_charts_common/lib/src/chart/pie/arc_renderer_config.dart
@@ -15,6 +15,7 @@
 
 import 'dart:math' show pi;
 
+import '../../common/color.dart';
 import '../../common/symbol_renderer.dart';
 import '../layout/layout_view.dart' show LayoutViewPaintOrder;
 import 'arc_renderer.dart' show ArcRenderer;
@@ -33,6 +34,7 @@ class ArcRendererConfig<D> extends BaseArcRendererConfig<D> {
       int minHoleWidthForCenterContent = 30,
       double startAngle = -pi / 2,
       double strokeWidthPx = 2.0,
+      Color? strokeColor,
       SymbolRenderer? symbolRenderer})
       : super(
             customRendererId: customRendererId,
@@ -43,6 +45,7 @@ class ArcRendererConfig<D> extends BaseArcRendererConfig<D> {
             minHoleWidthForCenterContent: minHoleWidthForCenterContent,
             startAngle: startAngle,
             strokeWidthPx: strokeWidthPx,
+            strokeColor: strokeColor,
             arcRendererDecorators: arcRendererDecorators);
 
   @override

--- a/community_charts_common/lib/src/chart/pie/base_arc_renderer_config.dart
+++ b/community_charts_common/lib/src/chart/pie/base_arc_renderer_config.dart
@@ -84,8 +84,9 @@ abstract class BaseArcRendererConfig<D> extends LayoutViewConfig
       this.minHoleWidthForCenterContent = 30,
       this.startAngle = -pi / 2,
       this.strokeWidthPx = 2.0,
+      Color? strokeColor,
       SymbolRenderer? symbolRenderer})
       : noDataColor = StyleFactory.style.noDataColor,
-        stroke = StyleFactory.style.arcStrokeColor,
+        stroke = strokeColor ?? StyleFactory.style.arcStrokeColor,
         symbolRenderer = symbolRenderer ?? CircleSymbolRenderer();
 }


### PR DESCRIPTION
It is useful to be able to define different color arcs, especially when there are multiple arcs on the same screen.