### PR TITLE
Fix: static pass analysis pub.dev

### DIFF
--- a/community_charts_flutter/lib/src/canvas/line_painter.dart
+++ b/community_charts_flutter/lib/src/canvas/line_painter.dart
@@ -136,7 +136,7 @@ class LinePainter {
     // Array of points that is used to draw a connecting path when only a
     // partial dash pattern segment can be drawn in the remaining length of a
     // line segment (between two defined points in the shape).
-    var remainderPoints;
+    List<Offset>? remainderPoints;
 
     // Draw the path through all the rest of the points in the series.
     for (var pointIndex = 1; pointIndex < points.length; pointIndex++) {

--- a/community_charts_flutter/lib/src/chart_gesture_detector.dart
+++ b/community_charts_flutter/lib/src/chart_gesture_detector.dart
@@ -137,4 +137,4 @@ class ChartGestureDetector {
 }
 
 // Exposed for testing.
-typedef ChartContainerRenderObject _ContainerResolver();
+typedef _ContainerResolver = ChartContainerRenderObject Function();

--- a/community_charts_flutter/lib/src/graphics_factory.dart
+++ b/community_charts_flutter/lib/src/graphics_factory.dart
@@ -16,18 +16,18 @@
 import 'package:community_charts_common/community_charts_common.dart' as common
     show GraphicsFactory, LineStyle, TextElement, TextStyle;
 import 'package:flutter/widgets.dart'
-    show BuildContext, DefaultTextStyle, MediaQuery;
+    show BuildContext, DefaultTextStyle, MediaQuery, TextScaler;
 import 'line_style.dart' show LineStyle;
 import 'text_element.dart' show TextElement;
 import 'text_style.dart' show TextStyle;
 
 class GraphicsFactory implements common.GraphicsFactory {
-  final double textScaleFactor;
+  final TextScaler textScaler;
   final DefaultTextStyle defaultTextStyle;
 
   GraphicsFactory(BuildContext context,
       {GraphicsFactoryHelper helper = const GraphicsFactoryHelper()})
-      : textScaleFactor = helper.getTextScaleFactorOf(context),
+      : textScaler = helper.getTextScalerOf(context),
         defaultTextStyle = DefaultTextStyle.of(context);
 
   /// Returns a [TextStyle] object.
@@ -38,7 +38,7 @@ class GraphicsFactory implements common.GraphicsFactory {
   /// Returns a text element from [text].
   @override
   common.TextElement createTextElement(String text) {
-    return TextElement(text, textScaleFactor: textScaleFactor)
+    return TextElement(text, textScaler: textScaler)
       ..textStyle = createTextPaint();
   }
 
@@ -50,6 +50,6 @@ class GraphicsFactory implements common.GraphicsFactory {
 class GraphicsFactoryHelper {
   const GraphicsFactoryHelper();
 
-  double getTextScaleFactorOf(BuildContext context) =>
-      MediaQuery.textScaleFactorOf(context);
+  TextScaler getTextScalerOf(BuildContext context) =>
+      MediaQuery.textScalerOf(context);
 }

--- a/community_charts_flutter/lib/src/text_element.dart
+++ b/community_charts_flutter/lib/src/text_element.dart
@@ -22,7 +22,14 @@ import 'package:community_charts_common/community_charts_common.dart' as common
         TextMeasurement,
         TextStyle;
 import 'package:flutter/rendering.dart'
-    show Color, TextBaseline, TextPainter, TextSpan, TextStyle, FontWeight;
+    show
+        Color,
+        FontWeight,
+        TextBaseline,
+        TextPainter,
+        TextScaler,
+        TextSpan,
+        TextStyle;
 
 /// Flutter implementation for text measurement and painter.
 class TextElement implements common.TextElement {
@@ -31,7 +38,7 @@ class TextElement implements common.TextElement {
   @override
   final String text;
 
-  final double? textScaleFactor;
+  final TextScaler? textScaler;
 
   var _painterReady = false;
   common.TextStyle? _textStyle;
@@ -46,7 +53,7 @@ class TextElement implements common.TextElement {
 
   double? _opacity;
 
-  TextElement(this.text, {common.TextStyle? style, this.textScaleFactor})
+  TextElement(this.text, {common.TextStyle? style, this.textScaler})
       : _textStyle = style;
 
   @override
@@ -163,8 +170,8 @@ class TextElement implements common.TextElement {
           ? ellipsis
           : null;
 
-    if (textScaleFactor != null) {
-      _textPainter.textScaleFactor = textScaleFactor!;
+    if (textScaler != null) {
+      _textPainter.textScaler = textScaler!;
     }
 
     _textPainter.layout(maxWidth: maxWidth?.toDouble() ?? double.infinity);

--- a/community_charts_flutter/test/text_element_test.dart
+++ b/community_charts_flutter/test/text_element_test.dart
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:flutter/material.dart' show BuildContext;
+import 'package:flutter/material.dart' show BuildContext, TextScaler;
 import 'package:flutter/widgets.dart' show InheritedWidget;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:community_charts_flutter/src/graphics_factory.dart';
@@ -30,24 +30,24 @@ class FakeBuildContext extends Fake implements BuildContext {
 
 // Gave up trying to figure out how to use mockito for now.
 class FakeGraphicsFactoryHelper extends Fake implements GraphicsFactoryHelper {
-  double textScaleFactor;
+  TextScaler textScaler;
 
-  FakeGraphicsFactoryHelper(this.textScaleFactor);
+  FakeGraphicsFactoryHelper(this.textScaler);
 
   @override
-  double getTextScaleFactorOf(BuildContext context) => textScaleFactor;
+  TextScaler getTextScalerOf(BuildContext context) => textScaler;
 }
 
 void main() {
   test('Text element gets assigned scale factor', () {
     final context = FakeBuildContext();
-    final helper = FakeGraphicsFactoryHelper(3.0);
+    final helper = FakeGraphicsFactoryHelper(TextScaler.linear(3.0));
     final graphicsFactory = new GraphicsFactory(context, helper: helper);
 
     final textElement =
         graphicsFactory.createTextElement('test') as TextElement;
 
     expect(textElement.text, equals('test'));
-    expect(textElement.textScaleFactor, equals(3.0));
+    expect(textElement.textScaler, equals(3.0));
   });
 }


### PR DESCRIPTION
- fix:  An uninitialized variable should have an explicit type annotation.
- fix:  Use the generic function type syntax in 'typedef's.
- migrate `textScaleFactor` to `TextScaler`