### PR TITLE
Feature: set minimum step size for numeric ticks

### DIFF
--- a/community_charts_common/lib/src/chart/cartesian/axis/numeric_tick_provider.dart
+++ b/community_charts_common/lib/src/chart/cartesian/axis/numeric_tick_provider.dart
@@ -195,6 +195,19 @@ class NumericTickProvider extends BaseTickProvider<num> {
     }
   }
 
+  double? _minStepSize;
+
+  /// Sets the minimum step size between ticks.
+  ///
+  /// If the calculated step size is less than the minimum step size, the minimum step size
+  /// will be used.
+  ///
+  /// [minStepSize] the minimum step size between ticks.
+  set minStepSize(double minStepSize) {
+    assert(minStepSize > 0.0);
+    _minStepSize = minStepSize;
+  }
+
   List<Tick<num>> _getTicksFromHint({
     required ChartContext? context,
     required GraphicsFactory graphicsFactory,
@@ -434,7 +447,11 @@ class NumericTickProvider extends BaseTickProvider<num> {
           final stepStart = negativeRegionCount > 0
               ? (-1 * tmpStepSize * negativeRegionCount)
               : 0.0;
-          return _TickStepInfo(tmpStepSize, stepStart);
+          final stepSize = (_minStepSize != null && _minStepSize! > tmpStepSize)
+              ? _minStepSize!
+              : tmpStepSize;
+
+          return _TickStepInfo(stepSize, stepStart);
         }
       }
     } else {
@@ -454,7 +471,11 @@ class NumericTickProvider extends BaseTickProvider<num> {
         // But wait until the last step to prevent the cost of the formatter.
         final tmpStepStart = _getStepLessThan(low.toDouble(), tmpStepSize);
         if (tmpStepStart + (tmpStepSize * regionCount) >= high) {
-          return _TickStepInfo(tmpStepSize, tmpStepStart);
+          final stepSize = (_minStepSize != null && _minStepSize! > tmpStepSize)
+              ? _minStepSize!
+              : tmpStepSize;
+
+          return _TickStepInfo(stepSize, tmpStepStart);
         }
       }
     }

--- a/community_charts_common/lib/src/chart/cartesian/axis/spec/numeric_axis_spec.dart
+++ b/community_charts_common/lib/src/chart/cartesian/axis/spec/numeric_axis_spec.dart
@@ -119,6 +119,7 @@ class BasicNumericTickProviderSpec implements NumericTickProviderSpec {
   final int? desiredTickCount;
   final int? desiredMinTickCount;
   final int? desiredMaxTickCount;
+  final double? minStepSize;
 
   /// Creates a [TickProviderSpec] that dynamically chooses the number of
   /// ticks based on the extents of the data.
@@ -135,12 +136,14 @@ class BasicNumericTickProviderSpec implements NumericTickProviderSpec {
   /// [desiredMaxTickCount] automatically choose the best tick
   ///     count to produce the 'nicest' ticks but make sure we don't have more
   ///     than this many.
+  /// [minStepSize] the minimum step size between ticks.
   const BasicNumericTickProviderSpec(
       {this.zeroBound,
       this.dataIsInWholeNumbers,
       this.desiredTickCount,
       this.desiredMinTickCount,
-      this.desiredMaxTickCount});
+      this.desiredMaxTickCount,
+      this.minStepSize});
 
   @override
   NumericTickProvider createTickProvider(ChartContext context) {
@@ -151,7 +154,9 @@ class BasicNumericTickProviderSpec implements NumericTickProviderSpec {
     if (dataIsInWholeNumbers != null) {
       provider.dataIsInWholeNumbers = dataIsInWholeNumbers!;
     }
-
+    if (minStepSize != null) {
+      provider.minStepSize = minStepSize!;
+    }
     if (desiredMinTickCount != null ||
         desiredMaxTickCount != null ||
         desiredTickCount != null) {


### PR DESCRIPTION
Set the minimum step size for numeric ticks. If the calculated step size is less than the minimum step size, the minimum step size is used instead. Example usage: 

```
const charts.BasicNumericTickProviderSpec numericSpec = charts.BasicNumericTickProviderSpec(
      dataIsInWholeNumbers: true,
      zeroBound: true,
      minStepSize: 50, // min step size between ticks
);
```